### PR TITLE
Fix color and style of country picker in register screen

### DIFF
--- a/app/src/main/java/dev/baseio/discordjetpackcompose/ui/routes/dashboard/components/SearchBox.kt
+++ b/app/src/main/java/dev/baseio/discordjetpackcompose/ui/routes/dashboard/components/SearchBox.kt
@@ -42,6 +42,8 @@ fun SearchBox(currentValue: String, onValueChanged: (String) -> Unit) {
         value = currentValue,
         onValueChange = onValueChanged,
         colors = TextFieldDefaults.textFieldColors(
+            textColor = DiscordColorProvider.colors.onSurface,
+            cursorColor = DiscordColorProvider.colors.primary,
             backgroundColor = DiscordColorProvider.colors.onSurface.copy(alpha = 0.05f),
             focusedIndicatorColor = Color.Transparent,
             unfocusedIndicatorColor = Color.Transparent
@@ -53,12 +55,18 @@ fun SearchBox(currentValue: String, onValueChanged: (String) -> Unit) {
                 tint = DiscordColorProvider.colors.onSurface.copy(alpha = ContentAlpha.disabled)
             )
         },
-        placeholder = { Text(text = stringResource(id = R.string.country_picker_hint)) },
+        placeholder = {
+            Text(
+                text = stringResource(id = R.string.country_picker_hint),
+                color = DiscordColorProvider.colors.onSurface
+            )
+        },
         trailingIcon = {
             AnimatedVisibility(visible = currentValue.isNotBlank()) {
                 IconButton(onClick = { onValueChanged("") }) {
                     Icon(
                         imageVector = Icons.Default.Close,
+                        tint = DiscordColorProvider.colors.onSurface,
                         contentDescription = "countryPickerSearchBoxTrailingIcon"
                     )
                 }

--- a/app/src/main/java/dev/baseio/discordjetpackcompose/ui/routes/onboarding/screens/register/AuthTextField.kt
+++ b/app/src/main/java/dev/baseio/discordjetpackcompose/ui/routes/onboarding/screens/register/AuthTextField.kt
@@ -45,8 +45,10 @@ private fun contentColor() = DiscordColorProvider.colors.contentColorFor(Discord
 private fun textFieldColors() = TextFieldDefaults.textFieldColors(
   textColor = contentColor(),
   disabledTextColor = contentColor(),
+  cursorColor = DiscordColorProvider.colors.primary,
   backgroundColor = DiscordColorProvider.colors.secondaryBackground,
   focusedIndicatorColor = Color.Transparent, // hide the indicator
   unfocusedIndicatorColor = Color.Transparent,
-  disabledIndicatorColor = Color.Transparent, placeholderColor = contentColor()
+  disabledIndicatorColor = Color.Transparent,
+  placeholderColor = contentColor()
 )

--- a/app/src/main/java/dev/baseio/discordjetpackcompose/ui/routes/onboarding/screens/register/CountryPicker.kt
+++ b/app/src/main/java/dev/baseio/discordjetpackcompose/ui/routes/onboarding/screens/register/CountryPicker.kt
@@ -55,7 +55,8 @@ fun CountryPicker(
         coroutineScope.launch { sheetState.hide() }
     }
     ModalBottomSheetLayout(
-        sheetState = sheetState, sheetContent = {
+        sheetState = sheetState,
+        sheetContent = {
             Box(modifier = Modifier.fillMaxSize()) {
                 Column {
                     SearchBox(
@@ -82,7 +83,11 @@ fun CountryPicker(
                     }
                 }
             }
-        }, sheetShape = RoundedCornerShape(0), scrimColor = Color.Black.copy(alpha = 0.32f)
+        },
+      sheetShape = RoundedCornerShape(0),
+      sheetBackgroundColor = DiscordColorProvider.colors.surface,
+      sheetContentColor = DiscordColorProvider.colors.onPrimary,
+      scrimColor = Color.Black.copy(alpha = 0.32f)
     ) {
         backgroundContent()
     }

--- a/app/src/main/java/dev/baseio/discordjetpackcompose/ui/routes/onboarding/screens/register/RegisterScreen.kt
+++ b/app/src/main/java/dev/baseio/discordjetpackcompose/ui/routes/onboarding/screens/register/RegisterScreen.kt
@@ -11,9 +11,7 @@ import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.Button
 import androidx.compose.material.ButtonDefaults
 import androidx.compose.material.ExperimentalMaterialApi
-import dev.baseio.discordjetpackcompose.ui.theme.DiscordColorProvider
 import androidx.compose.material.ModalBottomSheetValue.Hidden
-import androidx.compose.material.Surface
 import androidx.compose.material.Text
 import androidx.compose.material.rememberModalBottomSheetState
 import androidx.compose.material.rememberScaffoldState
@@ -25,7 +23,6 @@ import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.TextStyle
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextAlign
-import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import androidx.hilt.navigation.compose.hiltViewModel
@@ -34,8 +31,7 @@ import dev.baseio.discordjetpackcompose.entities.CountryEntity
 import dev.baseio.discordjetpackcompose.navigator.ComposeNavigator
 import dev.baseio.discordjetpackcompose.navigator.DiscordRoute
 import dev.baseio.discordjetpackcompose.ui.components.DiscordScaffold
-import dev.baseio.discordjetpackcompose.ui.theme.DiscordJetpackComposeTheme
-import dev.baseio.discordjetpackcompose.ui.theme.design_default_color_background
+import dev.baseio.discordjetpackcompose.ui.theme.DiscordColorProvider
 import dev.baseio.discordjetpackcompose.ui.utils.Strings
 import dev.baseio.discordjetpackcompose.viewmodels.RegistrationViewModel
 import kotlinx.coroutines.launch
@@ -138,25 +134,25 @@ fun RegisterScreen(
                     Text(stringResource(id = Strings.next))
                 }
             }
-
-            CountryPicker(
-                sheetState = sheetState,
-                backgroundContent = {},
-                onCountrySelected = {
-                    selectedCountry = it
-                    coroutineScope.launch {
-                        sheetState.hide()
-                    }
-                },
-                countryList = registrationViewModel.filteredCountryList?.filter {
-                    it.name.contains(
-                        other = countrySearchQuery,
-                        ignoreCase = true
-                    )
-                },
-                countrySearchQuery = countrySearchQuery,
-                onQueryUpdated = { updatedQuery -> countrySearchQuery = updatedQuery }
-            )
         }
     }
+
+    CountryPicker(
+      sheetState = sheetState,
+      backgroundContent = {},
+      onCountrySelected = {
+          selectedCountry = it
+          coroutineScope.launch {
+              sheetState.hide()
+          }
+      },
+      countryList = registrationViewModel.filteredCountryList?.filter {
+          it.name.contains(
+            other = countrySearchQuery,
+            ignoreCase = true
+          )
+      },
+      countrySearchQuery = countrySearchQuery,
+      onQueryUpdated = { updatedQuery -> countrySearchQuery = updatedQuery }
+    )
 }

--- a/app/src/main/java/dev/baseio/discordjetpackcompose/ui/theme/Color.kt
+++ b/app/src/main/java/dev/baseio/discordjetpackcompose/ui/theme/Color.kt
@@ -172,7 +172,7 @@ val design_dark_default_color_primary_dark = Color(0xFF000000)
 val design_dark_default_color_primary_variant = Color(0xFF3700b3)
 val design_dark_default_color_secondary = Color(0xFF03dac6)
 val design_dark_default_color_secondary_variant = Color(0xFF03dac6)
-val design_dark_default_color_surface = Color(0xFF121212)
+val design_dark_default_color_surface = Color(0xFF383842)
 val design_default_color_background = Color(0xFFffffff)
 val design_default_color_secondary_background = Color(0xffe4e5e8)
 


### PR DESCRIPTION
This fixes the usage of Material theme debug colors in Color picker.
Also fixes the position of the Bottom sheet dialog (color picker) and shows in full screen when scrolled.

![Screenshot_2022-07-10-23-00-03-13_42d112e099d159352908a1014f9aa3fd](https://user-images.githubusercontent.com/19844292/178155643-e0e22104-472d-4c38-8191-088c704aed51.jpg)
![Screenshot_2022-07-10-23-00-40-32_42d112e099d159352908a1014f9aa3fd](https://user-images.githubusercontent.com/19844292/178155647-262b82a5-7db3-44e4-8282-6602257867d1.jpg)

