### PR TITLE
Fixed composables not using system bars padding

### DIFF
--- a/app/src/main/java/dev/baseio/discordjetpackcompose/ui/routes/dashboard/main/DashboardScreen.kt
+++ b/app/src/main/java/dev/baseio/discordjetpackcompose/ui/routes/dashboard/main/DashboardScreen.kt
@@ -5,13 +5,12 @@ import androidx.compose.animation.fadeIn
 import androidx.compose.animation.fadeOut
 import androidx.compose.foundation.background
 import androidx.compose.foundation.gestures.Orientation
+import androidx.compose.foundation.isSystemInDarkTheme
 import androidx.compose.foundation.layout.Box
-import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.fillMaxHeight
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.offset
-import androidx.compose.foundation.layout.padding
 import androidx.compose.material.ExperimentalMaterialApi
 import androidx.compose.material.FractionalThreshold
 import androidx.compose.material.ModalBottomSheetValue
@@ -35,6 +34,7 @@ import androidx.compose.ui.platform.LocalDensity
 import androidx.compose.ui.unit.IntOffset
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.zIndex
+import com.google.accompanist.insets.statusBarsPadding
 import com.google.accompanist.systemuicontroller.rememberSystemUiController
 import dev.baseio.discordjetpackcompose.entities.ChatUserEntity
 import dev.baseio.discordjetpackcompose.entities.server.ServerEntity
@@ -158,9 +158,20 @@ fun DashboardScreen(
         derivedStateOf { (swipeableState.offset.value - screenCenterPx).roundToInt() }
     }
 
+    val systemUiController = rememberSystemUiController()
+    val isSystemInDarkTheme = isSystemInDarkTheme()
+
+    SideEffect {
+        systemUiController.setNavigationBarColor(
+            color = Color.Transparent,
+            darkIcons = !isSystemInDarkTheme
+        )
+    }
+
     Box(
         modifier = Modifier
-            .fillMaxSize(),
+            .fillMaxSize()
+            .statusBarsPadding(),
     ) {
         var selectedServerId: String? by remember { mutableStateOf(null) }
         val sheetState = rememberModalBottomSheetState(initialValue = ModalBottomSheetValue.Hidden)

--- a/app/src/main/java/dev/baseio/discordjetpackcompose/ui/routes/onboarding/screens/welcome/WelcomeScreen.kt
+++ b/app/src/main/java/dev/baseio/discordjetpackcompose/ui/routes/onboarding/screens/welcome/WelcomeScreen.kt
@@ -2,17 +2,22 @@ package dev.baseio.discordjetpackcompose.ui.routes.onboarding.screens.welcome
 
 import androidx.compose.foundation.Image
 import androidx.compose.foundation.background
-import androidx.compose.foundation.layout.*
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
 import androidx.compose.material.Button
 import androidx.compose.material.ButtonDefaults.buttonColors
-import dev.baseio.discordjetpackcompose.ui.theme.DiscordColorProvider
 import androidx.compose.material.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.SideEffect
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.ColorFilter
-import androidx.compose.ui.graphics.ColorFilter.Companion
 import androidx.compose.ui.res.colorResource
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
@@ -21,11 +26,13 @@ import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
+import com.google.accompanist.insets.systemBarsPadding
 import com.google.accompanist.systemuicontroller.rememberSystemUiController
-import dev.baseio.discordjetpackcompose.navigator.ComposeNavigator
 import dev.baseio.discordjetpackcompose.R
+import dev.baseio.discordjetpackcompose.navigator.ComposeNavigator
 import dev.baseio.discordjetpackcompose.navigator.DiscordScreen
 import dev.baseio.discordjetpackcompose.ui.routes.onboarding.commonui.CenteredTitleSubtitle
+import dev.baseio.discordjetpackcompose.ui.theme.DiscordColorProvider
 
 @Composable
 fun WelcomeScreen(composeNavigator: ComposeNavigator) {
@@ -40,6 +47,7 @@ fun WelcomeScreen(composeNavigator: ComposeNavigator) {
     Column(
         Modifier
             .fillMaxSize()
+            .systemBarsPadding()
             .background(DiscordColorProvider.colors.background),
         verticalArrangement = Arrangement.SpaceAround
     ) {


### PR DESCRIPTION
This PR deals with the issue where the system bars are overlapping the composables (because of the enabled edge-to-edge mode) and neither the composables are using system bars padding nor the system bars are setting its colors to Transparent to let content become see-through.